### PR TITLE
[fix] cuda 환경에서 발생하는 오류 해결 (PPO)

### DIFF
--- a/_01_code/_13_PPO/_01_ppo/_01_continuous/a_actor_and_critic.py
+++ b/_01_code/_13_PPO/_01_ppo/_01_continuous/a_actor_and_critic.py
@@ -45,9 +45,9 @@ class Actor(nn.Module):
         if exploration:
             dist = Normal(loc=mu_v, scale=std_v)
             action = dist.sample()
-            action = torch.clamp(action, min=-1.0, max=1.0).detach().numpy()
+            action = torch.clamp(action, min=-1.0, max=1.0).detach().cpu().numpy()  # cuda -> cpu -> numpy
         else:
-            action = torch.clamp(mu_v, min=-1.0, max=1.0).detach().numpy()
+            action = torch.clamp(mu_v, min=-1.0, max=1.0).detach().cpu().numpy()
 
         return action
 
@@ -63,6 +63,7 @@ class Critic(nn.Module):
         self.fc1 = nn.Linear(n_features, 128)
         self.fc2 = nn.Linear(128, 128)
         self.fc3 = nn.Linear(128, 1)
+        self.to(DEVICE)
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         if isinstance(x, np.ndarray):

--- a/_01_code/_13_PPO/_01_ppo/_02_discrete/a_actor_and_critic.py
+++ b/_01_code/_13_PPO/_01_ppo/_02_discrete/a_actor_and_critic.py
@@ -38,9 +38,9 @@ class Actor(nn.Module):
         if exploration:
             dist = Categorical(probs=mu_v)
             action = dist.sample()
-            action = action.detach().numpy()
+            action = action.detach().cpu().numpy()
         else:
-            action = torch.argmax(mu_v).detach().numpy()
+            action = torch.argmax(mu_v).detach().cpu().numpy()
 
         return action
 
@@ -56,7 +56,8 @@ class Critic(nn.Module):
         self.fc1 = nn.Linear(n_features, 128)
         self.fc2 = nn.Linear(128, 128)
         self.fc3 = nn.Linear(128, 1)
-
+        self.to(DEVICE)
+        
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         if isinstance(x, np.ndarray):
             x = torch.tensor(x, dtype=torch.float32, device=DEVICE)

--- a/_01_code/_13_PPO/_02_async_ppo/_01_continuous/b_actor_and_critic.py
+++ b/_01_code/_13_PPO/_02_async_ppo/_01_continuous/b_actor_and_critic.py
@@ -45,9 +45,9 @@ class Actor(nn.Module):
         if exploration:
             dist = Normal(loc=mu_v, scale=std_v)
             action = dist.sample()
-            action = torch.clamp(action, min=-1.0, max=1.0).detach().numpy()
+            action = torch.clamp(action, min=-1.0, max=1.0).detach().cpu().numpy()
         else:
-            action = torch.clamp(mu_v, min=-1.0, max=1.0).detach().numpy()
+            action = torch.clamp(mu_v, min=-1.0, max=1.0).detach().cpu().numpy()
 
         return action
 
@@ -63,6 +63,7 @@ class Critic(nn.Module):
         self.fc1 = nn.Linear(n_features, 128)
         self.fc2 = nn.Linear(128, 128)
         self.fc3 = nn.Linear(128, 1)
+        self.to(DEVICE)
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         if isinstance(x, np.ndarray):

--- a/_01_code/_13_PPO/_02_async_ppo/_02_discrete/b_actor_and_critic.py
+++ b/_01_code/_13_PPO/_02_async_ppo/_02_discrete/b_actor_and_critic.py
@@ -38,9 +38,9 @@ class Actor(nn.Module):
         if exploration:
             dist = Categorical(probs=mu_v)
             action = dist.sample()
-            action = action.detach().numpy()
+            action = action.detach().cpu().numpy()
         else:
-            action = torch.argmax(mu_v).detach().numpy()
+            action = torch.argmax(mu_v).detach().cpu().numpy()
 
         return action
 
@@ -56,6 +56,7 @@ class Critic(nn.Module):
         self.fc1 = nn.Linear(n_features, 128)
         self.fc2 = nn.Linear(128, 128)
         self.fc3 = nn.Linear(128, 1)
+        self.to(DEVICE)
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         if isinstance(x, np.ndarray):


### PR DESCRIPTION
## Summary
PPO 코드에서 발생하는 TypeError, RuntimeError를 해결합니다.

1. TypeError: numpy는 cuda 메모리를 직접 지원하지 않습니다. 따라서 `tensor.cpu()`를 거쳐서 numpy 배열로 변환해야 합니다.
2. RuntimeError: Critic 모델의 매개변수를 `DEVICE`에 할당시키는 코드가 없어 항상 `cpu`에 할당됩니다. 이는 `cuda` tensor와의 충돌을 일으킵니다. 따라서 `self.to(DEVICE)` 를 추가해야 합니다.